### PR TITLE
Lazy load `ActionController` and `Routing` matchers for `ActionController::TestCase`

### DIFF
--- a/lib/shoulda/matchers/integrations/libraries/action_controller.rb
+++ b/lib/shoulda/matchers/integrations/libraries/action_controller.rb
@@ -12,14 +12,16 @@ module Shoulda
           def integrate_with(test_framework)
             test_framework.include(matchers_module, type: :controller)
 
-            include_into(::ActionController::TestCase, matchers_module) do
-              def subject # rubocop:disable Lint/NestedMethodDefinition
-                @controller
+            self.tap do |instance|
+              ActiveSupport.on_load(:action_controller_test_case, run_once: true) do
+                instance.include_into(::ActionController::TestCase, instance.matchers_module) do
+                  def subject # rubocop:disable Lint/NestedMethodDefinition
+                    @controller
+                  end
+                end
               end
             end
           end
-
-          private
 
           def matchers_module
             Shoulda::Matchers::ActionController

--- a/lib/shoulda/matchers/integrations/libraries/routing.rb
+++ b/lib/shoulda/matchers/integrations/libraries/routing.rb
@@ -12,10 +12,12 @@ module Shoulda
           def integrate_with(test_framework)
             test_framework.include(matchers_module, type: :routing)
 
-            include_into(::ActionController::TestCase, matchers_module)
+            self.tap do |instance|
+              ActiveSupport.on_load(:action_controller_test_case, run_once: true) do
+                instance.include_into(::ActionController::TestCase, instance.matchers_module)
+              end
+            end
           end
-
-          private
 
           def matchers_module
             Shoulda::Matchers::Routing


### PR DESCRIPTION
This PR sets up two `on_load` hooks to include the `ActionController` and `Routing` matchers modules into `ActionController::TestCase`. They run only when `ActionController::TestCase` is loaded rather than immediately whenever the `integrate_with` method is called.

This change should improve app booting performance by delaying the inclusion of the matchers until they are actually needed.